### PR TITLE
Adding deepvariant for Ticket#0252798

### DIFF
--- a/recipes/deepvariant-1.8.0.eb
+++ b/recipes/deepvariant-1.8.0.eb
@@ -20,11 +20,11 @@ installopts += '-n %(namelower)s '
 installopts += '-v %(version)s '
 
 container_path = '/cvmfs/containers.computecanada.ca/content/containers/%(namelower)s-%(version)s'
-aliases = ["qiime"]
+aliases = ["deepvariant"]
 apptainer_params = '-c'
 
 sanity_check_paths = {
-    'files': ["opt/deepvariant/bin/deepvariant"],
+    'files': ["opt/deepvariant/bin/run_deepvariant"],
     'dirs': ["opt/deepvariant/bin"],
 }
 

--- a/recipes/deepvariant-1.8.0.eb
+++ b/recipes/deepvariant-1.8.0.eb
@@ -1,0 +1,31 @@
+# Author: Maxime Boissonneault
+# Digital Research Alliance of Canada - Calcul Québec - Université Laval
+
+easyblock = 'Apptainer'
+
+name = 'deepvariant'
+version = '1.8.0'
+
+homepage = 'https://github.com/google/deepvariant'
+description = """DeepVariant is a deep learning-based variant caller that takes aligned reads (in BAM or CRAM format), produces pileup image tensors from them, classifies each tensor using a convolutional neural network, and finally reports the results in a standard VCF or gVCF file.
+
+DeepVariant supports germline variant-calling in diploid organisms."""
+
+toolchain = SYSTEM
+dependencies = [('Apptainer', '1')]
+
+installopts = '-s google/deepvariant '
+installopts += '-i image '
+installopts += '-n %(namelower)s '
+installopts += '-v %(version)s '
+
+container_path = '/cvmfs/containers.computecanada.ca/content/containers/%(namelower)s-%(version)s'
+aliases = ["qiime"]
+apptainer_params = '-c'
+
+sanity_check_paths = {
+    'files': ["opt/deepvariant/bin/deepvariant"],
+    'dirs': ["opt/deepvariant/bin"],
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
Container builds as expected with
`build_container_image.sh -i image -n deepvariant -v 1.8.0 -s google/deepvariant:1.8.0 -t sif`

Tested a small sample dataset. 