### PR TITLE
setting APPTAINER_TMPDIR to /tmp

### DIFF
--- a/build_container_image.sh
+++ b/build_container_image.sh
@@ -5,6 +5,7 @@
 
 SCRIPT=$(readlink -f "$0")
 export TMPDIR=/tmp
+export APPTAINER_TMPDIR=/tmp
 if [[ ! -z $CONTAINER_BUILDER_TARGET_DIR ]]; then
 	TARGET_DIR=$CONTAINER_BUILDER_TARGET_DIR
 else


### PR DESCRIPTION
make sure that /var/tmp is not filled when `apptainer build` runs 